### PR TITLE
scale position.z by fudgeFactor only

### DIFF
--- a/webgl/lessons/webgl-3d-perspective.html
+++ b/webgl/lessons/webgl-3d-perspective.html
@@ -119,7 +119,7 @@ void main() {
 *  vec4 position = u_matrix * a_position;
 
   // Adjust the z to divide by
-+  float zToDivideBy = (1.0 + position.z) * u_fudgeFactor;
++  float zToDivideBy = 1.0 + position.z * u_fudgeFactor;
 
   // Divide x and y by z.
 *  gl_Position = vec4(position.xy / zToDivideBy, position.zw);
@@ -514,6 +514,3 @@ Now it represents -1 to +1 units across.
 
 
 </html>
-
-
-

--- a/webgl/lessons/webgl-3d-perspective.md
+++ b/webgl/lessons/webgl-3d-perspective.md
@@ -64,7 +64,7 @@ void main() {
 *  vec4 position = u_matrix * a_position;
 
   // Adjust the z to divide by
-+  float zToDivideBy = (1.0 + position.z) * u_fudgeFactor;
++  float zToDivideBy = 1.0 + position.z * u_fudgeFactor;
 
   // Divide x and y by z.
 *  gl_Position = vec4(position.xy / zToDivideBy, position.zw);
@@ -367,5 +367,3 @@ see 2 units when it's at zNear we need to move it pretty far away from the origi
 Now it represents -1 to +1 units across.
 </p>
 </div>
-
-


### PR DESCRIPTION
While you're actual code is correct:
float zToDivideBy = 1.0 + position.z * u_fudgeFactor;

Your example is incorrect:
float zToDivideBy = (1.0 + position.z) * u_fudgeFactor;

We should scale position.z by u_fudgeFactor then add 1 to translate zToDivideBy from clipspace -1 1 to 0 2