### PR TITLE
Translation and Fixes

### DIFF
--- a/webgl/lessons/pt-br/langinfo.hanson
+++ b/webgl/lessons/pt-br/langinfo.hanson
@@ -6,7 +6,7 @@
   description: 'WebGL2 do início. Sem Truques',
   link: 'http://webglfundamentals.org/webgl/lessons/pt-br',
   commentSectionHeader: '<div>Dúvidas? <a href="http://stackoverflow.com/questions/tagged/webgl2">Pergunte no stackoverflow</a>.</div>\n        <div>Problemas/Bug? <a href="http://github.com/greggman/webgl2-fundamentals/issues">Pergunte no github</a>.</div>',
-  missing: "Sentimos muito, mas este artigo não foi traduzido, ainda! [Traduções são sempre bem vindas](https://github.com/greggman/webgl2-fundamentals)! 😄\n\n[Aqui está o artigo original, em Inglês, por enquanto]({{{origLink}}}).",
+  missing: "Sentimos muito, mas este artigo não foi traduzido, ainda! [Traduções são sempre bem vindas](https://github.com/greggman/webgl2-fundamentals)! 😄\n\n[Aqui está o link para o artigo original, em Inglês, por enquanto]({{{origLink}}}).",
   toc: 'Índice',
 }
 

--- a/webgl/lessons/pt-br/toc.html
+++ b/webgl/lessons/pt-br/toc.html
@@ -1,88 +1,88 @@
 <ul>
   <li>Fundamentos</li>
   <ul>
-    <li><a href="/webgl/lessons/webgl-getting-webgl2.html">Como utilizar a WebGL2</a></li>
-    <li><a href="/webgl/lessons/webgl-fundamentals.html">Fundamentos da WebGL2</a></li>
-    <li><a href="/webgl/lessons/webgl-how-it-works.html">Como Funciona a WebGL2</a></li>
-    <li><a href="/webgl/lessons/webgl-shaders-and-glsl.html">WebGL2 Shaders e GLSL</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-getting-webgl2.html">Como utilizar a WebGL2</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-fundamentals.html">Fundamentos da WebGL2</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-how-it-works.html">Como Funciona a WebGL2</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-shaders-and-glsl.html">WebGL2 Shaders e GLSL</a></li>
   </ul>
   <li>WebGL2 vs WebGL1</li>
   <ul>
-    <li><a href="/webgl/lessons/webgl2-whats-new.html">O que há de novo na WebGL2</a></li>
-    <li><a href="/webgl/lessons/webgl1-to-webgl2.html">Migrando do WebGL1 para a WebGL2</a></li>
-    <li><a href="/webgl/lessons/webgl1-to-webgl2-fundamentals.html">Diferenças entre a WebGLFundamentals.org e a WebGL2Fundamentals.org</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl2-whats-new.html">O que há de novo na WebGL2</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl1-to-webgl2.html">Migrando do WebGL1 para a WebGL2</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl1-to-webgl2-fundamentals.html">Diferenças entre a WebGLFundamentals.org e a WebGL2Fundamentals.org</a></li>
   </ul>
   <li>Processamento de Imagem</li>
   <ul>
-    <li><a href="/webgl/lessons/webgl-image-processing.html">Processamento de Imagem WebGL2</a></li>
-    <li><a href="/webgl/lessons/webgl-image-processing-continued.html">Processamento de Imagem Continuada WebGL2</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-image-processing.html">Processamento de Imagem WebGL2</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-image-processing-continued.html">Processamento de Imagem Continuada WebGL2</a></li>
   </ul>
   <li>Translação 2D, rotação, escala, matriz matemática</li>
   <ul>
-    <li><a href="/webgl/lessons/webgl-2d-translation.html">Translação 2D WebGL2</a></li>
-    <li><a href="/webgl/lessons/webgl-2d-rotation.html">Rotação 2D WebGL2</a></li>
-    <li><a href="/webgl/lessons/webgl-2d-scale.html">Escala 2D WebGL2</a></li>
-    <li><a href="/webgl/lessons/webgl-2d-matrices.html">Matrizes 2D WebGL2</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-2d-translation.html">Translação 2D WebGL2</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-2d-rotation.html">Rotação 2D WebGL2</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-2d-scale.html">Escala 2D WebGL2</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-2d-matrices.html">Matrizes 2D WebGL2</a></li>
   </ul>
   <li>3D</li>
   <ul>
-    <li><a href="/webgl/lessons/webgl-3d-orthographic.html">WebGL2 - 3D ortogonal</a></li>
-    <li><a href="/webgl/lessons/webgl-3d-perspective.html">WebGL2 Perspectiva 3D</a></li>
-    <li><a href="/webgl/lessons/webgl-3d-camera.html">WebGL2 3D - Câmeras</a></li>
-    <li><a href="/webgl/lessons/webgl-matrix-naming.html">WebGL2 3D - Nomenclatura das Matrizes</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-3d-orthographic.html">WebGL2 - 3D ortogonal</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-3d-perspective.html">WebGL2 Perspectiva 3D</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-3d-camera.html">WebGL2 3D - Câmeras</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-matrix-naming.html">WebGL2 3D - Nomenclatura das Matrizes</a></li>
   </ul>
   <li>Iluminação</li>
   <ul>
-    <li><a href="/webgl/lessons/webgl-3d-lighting-directional.html">WebGL2 3D - Iluminação Direcional</a></li>
-    <li><a href="/webgl/lessons/webgl-3d-lighting-point.html">WebGL2 3D - Iluminação de Pontos</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-3d-lighting-directional.html">WebGL2 3D - Iluminação Direcional</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-3d-lighting-point.html">WebGL2 3D - Iluminação de Pontos</a></li>
   </ul>
   <li>Estrutura e Organização</li>
   <ul>
-    <li><a href="/webgl/lessons/webgl-less-code-more-fun.html">WebGL2 - Menos Código, Mais Diversão</a></li>
-    <li><a href="/webgl/lessons/webgl-drawing-multiple-things.html">WebGL2 - Desenhando Múltiplas Coisas</a></li>
-    <li><a href="/webgl/lessons/webgl-scene-graph.html">WebGL2 - Gráficos de Cena</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-less-code-more-fun.html">WebGL2 - Menos Código, Mais Diversão</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-drawing-multiple-things.html">WebGL2 - Desenhando Múltiplas Coisas</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-scene-graph.html">WebGL2 - Gráficos de Cena</a></li>
   </ul>
   <li>Geometria</li>
   <ul>
-    <li><a href="/webgl/lessons/webgl-3d-geometry-lathe.html">WebGL2 Geometria 3D - Torno</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-3d-geometry-lathe.html">WebGL2 Geometria 3D - Torno</a></li>
   </ul>
   <li>Texturas</li>
   <ul>
-    <li><a href="/webgl/lessons/webgl-3d-textures.html">WebGL2 3D - Texturas</a></li>
-    <li><a href="/webgl/lessons/webgl-data-textures.html">WebGL2 - Textura de Dados</a></li>
-    <li><a href="/webgl/lessons/webgl-2-textures.html">WebGL2 - Usando 2 ou Mais Texturas</a></li>
-    <li><a href="/webgl/lessons/webgl-cors-permission.html">WebGL2 - Cross Origin Images</a></li>
-    <li><a href="/webgl/lessons/webgl-3d-perspective-correct-texturemapping.html">WebGL2 3D - Perspective Correct Texture Mapping</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-3d-textures.html">WebGL2 3D - Texturas</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-data-textures.html">WebGL2 - Textura de Dados</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-2-textures.html">WebGL2 - Usando 2 ou Mais Texturas</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-cors-permission.html">WebGL2 - Cross Origin Images</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-3d-perspective-correct-texturemapping.html">WebGL2 3D - Perspective Correct Texture Mapping</a></li>
   </ul>
   <li>Renderizando Uma Textura</li>
   <ul>
-    <li><a href="/webgl/lessons/webgl-render-to-texture.html">WebGL2 - Renderizar Uma Textura</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-render-to-texture.html">WebGL2 - Renderizar Uma Textura</a></li>
   </ul>
   </li>
   <li>Técnicas</li>
   <ul>
     <li>2D</li>
     <ul>
-      <li><a href="/webgl/lessons/webgl-2d-drawimage.html">WebGL2 2D - DrawImage</a>
-      <li><a href="/webgl/lessons/webgl-2d-matrix-stack.html">WebGL2 2D - Matrix Stack</a>
+      <li><a href="/webgl/lessons/pt-br/webgl-2d-drawimage.html">WebGL2 2D - DrawImage</a>
+      <li><a href="/webgl/lessons/pt-br/webgl-2d-matrix-stack.html">WebGL2 2D - Matrix Stack</a>
     </ul>
     <li>Text</li>
     <ul>
-      <li><a href="/webgl/lessons/webgl-text-html.html">WebGL2 Text - HTML</a>
-      <li><a href="/webgl/lessons/webgl-text-canvas2d.html">WebGL2 Text - Canvas 2D</a>
-      <li><a href="/webgl/lessons/webgl-text-texture.html">WebGL2 Text - Usando Uma Textura</a>
-      <li><a href="/webgl/lessons/webgl-text-glyphs.html">WebGL2 Text - Usando uma Textura Glyph</a>
+      <li><a href="/webgl/lessons/pt-br/webgl-text-html.html">WebGL2 Text - HTML</a>
+      <li><a href="/webgl/lessons/pt-br/webgl-text-canvas2d.html">WebGL2 Text - Canvas 2D</a>
+      <li><a href="/webgl/lessons/pt-br/webgl-text-texture.html">WebGL2 Text - Usando Uma Textura</a>
+      <li><a href="/webgl/lessons/pt-br/webgl-text-glyphs.html">WebGL2 Text - Usando uma Textura Glyph</a>
     </ul>
   </ul>
   <li>Diversos</li>
   <ul>
-    <li><a href="/webgl/lessons/webgl-setup-and-installation.html">WebGL2 Configuração e Instalação</a></li>
-    <li><a href="/webgl/lessons/webgl-boilerplate.html">WebGL2 Boilerplate</a></li>
-    <li><a href="/webgl/lessons/webgl-resizing-the-canvas.html">WebGL2 Redimensionando o Canvas</a></li>
-    <li><a href="/webgl/lessons/webgl-animation.html">WebGL2 - Animação</a></li>
-    <li><a href="/webgl/lessons/webgl-and-alpha.html">WebGL2 e o Alpha</a></li>
-    <li><a href="/webgl/lessons/webgl-2d-vs-3d-library.html">WebGL2 - Bibliotecas 2D vs 3D</a></li>
-    <li><a href="/webgl/lessons/webgl-anti-patterns.html">WebGL2 - Anti-Patterns</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-setup-and-installation.html">WebGL2 Configuração e Instalação</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-boilerplate.html">WebGL2 Boilerplate</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-resizing-the-canvas.html">WebGL2 Redimensionando o Canvas</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-animation.html">WebGL2 - Animação</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-and-alpha.html">WebGL2 e o Alpha</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-2d-vs-3d-library.html">WebGL2 - Bibliotecas 2D vs 3D</a></li>
+    <li><a href="/webgl/lessons/pt-br/webgl-anti-patterns.html">WebGL2 - Anti-Patterns</a></li>
   </ul>
 </ul>
 <ul>

--- a/webgl/lessons/pt-br/webgl-fundamentals.md
+++ b/webgl/lessons/pt-br/webgl-fundamentals.md
@@ -1,0 +1,607 @@
+Title: Fundamentos da WebGL2
+Description: Sua primeira lição da WebGL2: começando com os fundamentos
+
+Primeiramente, esses artigos são sobre a WebGL2. Se você está interessado na WebGL 1.0
+[por favor, vá aqui](http://webglfundamentals.org). Observe que a WebGL2 é [quase 100% compatível
+com a WebGL1](webgl1-backward-compatibility.html). Dito isto, uma vez que você habilita a
+WebGL2, você também pode usá-la como ela deveria ser usada. Esses tutoriais seguem esse raciocínio.
+
+[test](#日本語のテクスト)
+
+Normalmente, a WebGL é vista como uma API 3D. As pessoas pensam: "eu irei usar a WebGL e como uma mágica,
+eu vou obter efeitos 3D super legais". Na realidade não é nada disso, a WebGL é apenas um mecanismo de rasterização. Ela desenha
+pontos, linhas e triângulos com base no código que você fornece. Colocar a WebGL para fazer qualquer outra coisa depende de você
+fornecer o código de modo que o uso dos pontos, linhas e triângulos sejam capazes de realizar sua tarefa.
+
+## 日本語のテクスト
+
+A WebGL é executada diretamente na GPU do seu computador. Como tal, você precisa indicar o código a ser executado na GPU.
+Você pode indicar o código na forma de pares de funções. Essas 2 funções são chamadas de vexter shader
+e fragment shader e cada uma delas está escrita em linguagem no estilo C/C++ estritamente tipada chamada
+[GLSL](webgl-shaders-and-glsl.html). (GL Shader Language). Juntas, elas são chamadas de *programa*.
+
+O trabalho da vertex shader é calcular as posições dos vértices. Com base nas posições que a função retornar,
+o WebGL pode então rasterizar vários tipos de primitivas, incluindo pontos, linhas ou triângulos.
+Ao rasterizar essas primitivas, ele chama uma segunda função fornecida pelo usuário chama fragment shader (sombreador de fragmento).
+O trabalho do fragment shader é calcula uma cor para cada pixel da primitiva sendo atualmente desenhada.
+
+Quase toda a API da WebGL se resume em configurar o estado para esses pares de funções a serem executadas.
+Para cada coisa que você deseja desenhar, configure um grupo de estados e execute um par de funções, chamando
+`gl.drawArrays` ou `gl.drawElements` que executa seus shaders (sombreadores) na GPU.
+
+Todos os dados que você deseja que essas funções tenham acesso devem ser fornecidas à GPU.
+Há quatro maneiras de como um shader é capaz de obter dados.
+
+1. Atributos, Buffers, e Vertex Arrays
+
+   Buffers são arrays de dados binários que você carrega na GPU. Normalmente, os buffers contêm
+   coisas como posições, normals, coordenadas de textura, cores de vértices, etc.
+   embora você esteja livre para colocar tudo o que quiser neles.
+
+   Os atributos são usados para especificar como   tirar dados dos seus buffers e fornecê-los para o seu vertex shader.
+   Por exemplo, você pode colocar posições em um buffer como 3 floats de 32bits
+   por posição. Você poderia dizer a um determinado atributo qual buffer irá extrair as posições, que tipo de
+   ele deve retirar (3 componentes de números de pontos flutuantes de 32 bits), qual offset
+   no buffer as posições se iniciam, e quantos bytes são necessários para obter de um a posição para o próximo.
+
+   Buffers não possuem acesso aleatórrio. Em vez disso, um vertex shaders é executado um número específico
+   de vezes. Cada vez que é executado, o próximo valor de cada buffer especificado é puxado
+   , e o seu valor é atribuído a um atributo.
+
+   O estado dos atributos, quais buffers usar para cada um e como extrair dados
+   desses buffers, é coletado em um vertex array object (VAO).
+
+2. Uniforms
+
+   Uniforms são, efetivamente, variáveis globais que você configurou antes de executar o seu shader.
+
+3. Texturas
+
+   As texturas são matrizes de dados que você pode acessar aleatoriamente no seu programa de sombreamento. A coisa mais
+   para se colocar em uma textura são dados de imagem, mas as apenas dados e podem facilmente
+   conter algo diferente das cores.
+
+4. Variáveis
+
+   As variáveis são uma maneira de um vertex shader passar dados para um fragment shader. Dependendo
+   do que está sendo renderizado, pontos, linhas, ou triângulos, os valores definidos em uma variável
+   por um vertex shader serão interpolados enquanto o fragment shader é executado.
+
+## WebGL Hello World
+
+WebGL only cares about 2 things. Clipspace coordinates and colors.
+Your job as a programmer using WebGL is to provide WebGL with those 2 things.
+You provide your 2 "shaders" to do this. A Vertex shader which provides the
+clipspace coordinates and a fragment shader that provides the color.
+
+Clipspace coordinates always go from -1 to +1 no matter what size your
+canvas is. Here is a simple WebGL example that shows WebGL in its simplest form.
+
+Let's start with a vertex shader
+
+    #version 300 es
+
+    // an attribute is an input (in) to a vertex shader.
+    // It will receive data from a buffer
+    in vec4 a_position;
+
+    // all shaders have a main function
+    void main() {
+
+      // gl_Position is a special variable a vertex shader
+      // is responsible for setting
+      gl_Position = a_position;
+    }
+
+When executed, if the entire thing was written in JavaScript instead of GLSL
+you could imagine it would be used like this
+
+    // *** PSUEDO CODE!! ***
+
+    var positionBuffer = [
+      0, 0, 0, 0,
+      0, 0.5, 0, 0,
+      0.7, 0, 0, 0,
+    ];
+    var attributes = {};
+    var gl_Position;
+
+    drawArrays(..., offset, count) {
+      var stride = 4;
+      var size = 4;
+      for (var i = 0; i < count; ++i) {
+         // copy the next 4 values from positionBuffer to the a_position attribute
+         attributes.a_position = positionBuffer.slice((offset + i) * stide, size);
+         runVertexShader();
+         ...
+         doSomethingWith_gl_Position();
+    }
+
+In reality it's not quite that simple because `positionBuffer` would need to be converted to binary
+data (see below) and so the actual computation for getting data out of the buffer
+would be a little different but hopefully this gives you an idea of how a vertex
+shader will be executed.
+
+Next we need a fragment shader
+
+    #version 300 es
+
+    // fragment shaders don't have a default precision so we need
+    // to pick one. mediump is a good default. It means "medium precision"
+    precision mediump float;
+
+    // we need to declare an output for the fragment shader
+    out vec4 outColor;
+
+    void main() {
+      // Just set the output to a constant redish-purple
+      outColor = vec4(1, 0, 0.5, 1);
+    }
+
+Above we declared `outColor` as our fragment shader's output. We're setting `outColor` to `1, 0, 0.5, 1`
+which is 1 for red, 0 for green, 0.5 for blue, 1 for alpha. Colors in WebGL go from 0 to 1.
+
+Now that we have written the 2 shader functions lets get started with WebGL
+
+First we need an HTML canvas element
+
+     <canvas id="c"></canvas>
+
+Then in JavaScript we can look that up
+
+     var canvas = document.getElementById("c");
+
+Now we can create a WebGL2RenderingContext
+
+     var gl = canvas.getContext("webgl2");
+     if (!gl) {
+        // no webgl2 for you!
+        ...
+
+Now we need to compile those shaders to put them on the GPU so first we need to get them into strings.
+You can create your GLSL strings any way you normally create strings in JavaScript. For example by concatenating,
+by using AJAX to download them, by putting them in non-javascript script tags, or in this case in
+multiline template strings.
+
+    var vertexShaderSource = `#version 300 es
+
+    // an attribute is an input (in) to a vertex shader.
+    // It will receive data from a buffer
+    in vec4 a_position;
+
+    // all shaders have a main function
+    void main() {
+
+      // gl_Position is a special variable a vertex shader
+      // is responsible for setting
+      gl_Position = a_position;
+    }
+    `;
+
+    var fragmentShaderSource = `#version 300 es
+
+    // fragment shaders don't have a default precision so we need
+    // to pick one. mediump is a good default. It means "medium precision"
+    precision mediump float;
+
+    // we need to declare an output for the fragment shader
+    out vec4 outColor;
+
+    void main() {
+      // Just set the output to a constant redish-purple
+      outColor = vec4(1, 0, 0.5, 1);
+    }
+    `;
+
+In fact, most 3D engines generate GLSL shaders on the fly using various types of templates, concatenation, etc.
+For the samples on this site though none of them are complex enough to need to generate GLSL at runtime.
+
+> NOTE: `#version 300 es` **MUST BE THE VERY FIRST LINE OF YOUR SHADER**. No comments or
+> blank lines are allowed before it! `#version 300 es` tells WebGL2 you want to use WebGL2's
+> shader language called GLSL ES 3.00. If you don't put that as the first line the shader
+> language defaults to WebGL 1.0's GLSL ES 1.00 which has many differences and far less features.
+
+Next we need a function that will create a shader, upload the GLSL source, and compile the shader.
+Note I haven't written any comments because it should be clear from the names of the functions
+what is happening.
+
+    function createShader(gl, type, source) {
+      var shader = gl.createShader(type);
+      gl.shaderSource(shader, source);
+      gl.compileShader(shader);
+      var success = gl.getShaderParameter(shader, gl.COMPILE_STATUS);
+      if (success) {
+        return shader;
+      }
+
+      console.log(gl.getShaderInfoLog(shader));
+      gl.deleteShader(shader);
+    }
+
+We can now call that function to create the 2 shaders
+
+    var vertexShader = createShader(gl, gl.VERTEX_SHADER, vertexShaderSource);
+    var fragmentShader = createShader(gl, gl.FRAGMENT_SHADER, fragmentShaderSource);
+
+We then need to *link* those 2 shaders into a *program*
+
+    function createProgram(gl, vertexShader, fragmentShader) {
+      var program = gl.createProgram();
+      gl.attachShader(program, vertexShader);
+      gl.attachShader(program, fragmentShader);
+      gl.linkProgram(program);
+      var success = gl.getProgramParameter(program, gl.LINK_STATUS);
+      if (success) {
+        return program;
+      }
+
+      console.log(gl.getProgramInfoLog(program));
+      gl.deleteProgram(program);
+    }
+
+And call it
+
+    var program = createProgram(gl, vertexShader, fragmentShader);
+
+Now that we've created a GLSL program on the GPU we need to supply data to it.
+The majority of the WebGL API is about setting up state to supply data to our GLSL programs.
+In this case our only input to our GLSL program is `a_position` which is an attribute.
+The first thing we should do is look up the location of the attribute for the program
+we just created
+
+    var positionAttributeLocation = gl.getAttribLocation(program, "a_position");
+
+Looking up attribute locations (and uniform locations) is something you should
+do during initialization, not in your render loop.
+
+Attributes get their data from buffers so we need to create a buffer
+
+    var positionBuffer = gl.createBuffer();
+
+WebGL lets us manipulate many WebGL resources on global bind points.
+You can think of bind points as internal global variables inside WebGL.
+First you bind a resource to a bind point. Then, all other functions
+refer to the resource through the bind point. So, let's bind the position buffer.
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+
+Now we can put data in that buffer by referencing it through the bind point
+
+    // three 2d points
+    var positions = [
+      0, 0,
+      0, 0.5,
+      0.7, 0,
+    ];
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(positions), gl.STATIC_DRAW);
+
+There's a lot going on here. The first thing is we have `positions` which is a
+JavaScript array. WebGL on other hand needs strongly typed data so the part
+`new Float32Array(positions)` creates a new array of 32bit floating point numbers
+and copies the values from `positions`. `gl.bufferData` then copies that data to
+the `positionBuffer` on the GPU. It's using the position buffer because we bound
+it to the `ARRAY_BUFFER` bind point above.
+
+The last argument, `gl.STATIC_DRAW` is a hint to WebGL about how we'll use the data.
+WebGL can try to use that hint to optimize certain things. `gl.STATIC_DRAW` tells WebGL
+we are not likely to change this data much.
+
+Now that we've put data in a buffer we need to tell the attribute how to get data
+out of it. First we need to create a collection of attribute state called a Vertex Array Object.
+
+    var vao = gl.createVertexArray();
+
+And we need to make that the current vertex array so that all of our attribute settings
+will apply to that set of attribute state
+
+    gl.bindVertexArray(vao);
+
+Now we finally setup the attributes in the vertex array. First off we need to turn the attribute on.
+This tells WebGL we want to get data out of a buffer. If we don't turn on the attribute
+then the attribute will have a constant value.
+
+    gl.enableVertexAttribArray(positionAttributeLocation);
+
+Then we need to specify how to pull the data out
+
+    var size = 2;          // 2 components per iteration
+    var type = gl.FLOAT;   // the data is 32bit floats
+    var normalize = false; // don't normalize the data
+    var stride = 0;        // 0 = move forward size * sizeof(type) each iteration to get the next position
+    var offset = 0;        // start at the beginning of the buffer
+    gl.vertexAttribPointer(
+        positionAttributeLocation, size, type, normalize, stride, offset)
+
+A hidden part of `gl.vertexAttribPointer` is that it binds the current `ARRAY_BUFFER`
+to the attribute. In other words now this attribute is bound to
+`positionBuffer`. That means we're free to bind something else to the `ARRAY_BUFFER` bind point.
+The attribute will continue to use `positionBuffer`.
+
+Note that from the point of view of our GLSL vertex shader the `a_position` attribute is a `vec4`
+
+    in vec4 a_position;
+
+`vec4` is a 4 float value. In JavaScript you could think of it something like
+`a_position = {x: 0, y: 0, z: 0, w: 0}`. Above we set `size = 2`. Attributes
+default to `0, 0, 0, 1` so this attribute will get its first 2 values (x and y)
+from our buffer. The z, and w will be the default 0 and 1 respectively.
+
+Before we draw we should resize the canvas to match its display size. Canvases just like Images have 2 sizes.
+The number of pixels actually in them and separately the size they are displayed. CSS determines the size
+the canvas is displayed. **You should always set the size you want a canvas with CSS** since it is far far
+more flexible than any other method.
+
+To make the number of pixels in the canvas match the size it's displayed
+[I'm using a helper function you can read about here](webgl-resizing-the-canvas.html).
+
+In nearly all of these samples the canvas size is 400x300 pixels if the sample is run in its own window
+but stretches to fill the available space if it's inside an iframe like it is on this page.
+By letting CSS determine the size and then adjusting to match we easily handle both of these cases.
+
+    webglUtils.resizeCanvasToDisplaySize(gl.canvas);
+
+We need to tell WebGL how to convert from the clip space
+values we'll be setting `gl_Position` to back into pixels, often called screen space.
+To do this we call `gl.viewport` and pass it the current size of the canvas.
+
+    gl.viewport(0, 0, gl.canvas.width, gl.canvas.height);
+
+This tells WebGL the -1 +1 clip space maps to 0 &lt;-&gt; `gl.canvas.width` for x and 0 &lt;-&gt; `gl.canvas.height`
+for y.
+
+We clear the canvas. `0, 0, 0, 0` are red, green, blue, alpha respectively so in this case we're making the canvas transparent.
+
+    // Clear the canvas
+    gl.clearColor(0, 0, 0, 0);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+
+Next we need to tell WebGL which shader program to execute.
+
+    // Tell it to use our program (pair of shaders)
+    gl.useProgram(program);
+
+Then we need to tell it which set of buffers use and how to pull data out of those buffers to
+supply to the attributes
+
+    // Bind the attribute/buffer set we want.
+    gl.bindVertexArray(vao);
+
+After all that we can finally ask WebGL to execute our GLSL program.
+
+    var primitiveType = gl.TRIANGLES;
+    var offset = 0;
+    var count = 3;
+    gl.drawArrays(primitiveType, offset, count);
+
+Because the count is 3 this will execute our vertex shader 3 times. The first time `a_position.x` and `a_position.y`
+in our vertex shader attribute will be set to the first 2 values from the positionBuffer.
+The 2nd time `a_position.xy` will be set to the 2nd two values. The last time it will be
+set to the last 2 values.
+
+Because we set `primitiveType` to `gl.TRIANGLES`, each time our vertex shader is run 3 times
+WebGL will draw a triangle based on the 3 values we set `gl_Position` to. No matter what size
+our canvas is those values are in clip space coordinates that go from -1 to 1 in each direction.
+
+Because our vertex shader is simply copying our positionBuffer values to `gl_Position` the
+triangle will be drawn at clip space coordinates
+
+      0, 0,
+      0, 0.5,
+      0.7, 0,
+
+Converting from clip space to screen space if the canvas size
+happned to be 400x300 we'd get something like this
+
+     clip space      screen space
+       0, 0       ->   200, 150
+       0, 0.5     ->   200, 225
+     0.7, 0       ->   340, 150
+
+WebGL will now render that triangle. For every pixel it is about to draw WebGL will call our fragment shader.
+Our fragment shader just sets `outColor` to `1, 0, 0.5, 1`. Since the Canvas is an 8bit
+per channel canvas that means WebGL is going to write the values `[255, 0, 127, 255]` into the canvas.
+
+Here's a live version
+
+{{{example url="../webgl-fundamentals.html" }}}
+
+In the case above you can see our vertex shader is doing nothing
+but passing on our position data directly. Since the position data is
+already in clipspace there is no work to do. *If you want 3D it's up to you
+to supply shaders that convert from 3D to clipspace because WebGL is only
+a rasterization API*.
+
+You might be wondering why does the triangle start in the middle and go to toward the top right.
+Clip space in `x` goes from -1 to +1. That means 0 is in the center and positive values will
+be to the right of that.
+
+As for why it's on the top, in clip space -1 is at the bottom and +1 is at the top. That means
+0 is in the center and so positive numbers will be above the center.
+
+For 2D stuff you would probably rather work in pixels than clipspace so
+let's change the shader so we can supply the position in pixels and have
+it convert to clipspace for us. Here's the new vertex shader
+
+    -  in vec4 a_position;
+    +  in vec2 a_position;
+
+    +  uniform vec2 u_resolution;
+
+      void main() {
+    +    // convert the position from pixels to 0.0 to 1.0
+    +    vec2 zeroToOne = a_position / u_resolution;
+    +
+    +    // convert from 0->1 to 0->2
+    +    vec2 zeroToTwo = zeroToOne * 2.0;
+    +
+    +    // convert from 0->2 to -1->+1 (clipspace)
+    +    vec2 clipSpace = zeroToTwo - 1.0;
+    +
+    *    gl_Position = vec4(clipSpace, 0, 1);
+      }
+
+Some things to notice about the changes. We changed `a_position` to a `vec2` since we're
+only using `x` and `y` anyway. A `vec2` is similar to a `vec4` but only has `x` and `y`.
+
+Next we added a `uniform` called `u_resolution`. To set that we need to look up its location.
+
+    var resolutionUniformLocation = gl.getUniformLocation(program, "u_resolution");
+
+The rest should be clear from the comments. By setting `u_resolution` to the resolution
+of our canvas the shader will now take the positions we put in `positionBuffer` supplied
+in pixels coordinates and convert them to clip space.
+
+Now we can change our position values from clip space to pixels. This time we're going to draw a rectangle
+made from 2 triangles, 3 points each.
+
+    var positions = [
+    *  10, 20,
+    *  80, 20,
+    *  10, 30,
+    *  10, 30,
+    *  80, 20,
+    *  80, 30,
+    ];
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(positions), gl.STATIC_DRAW);
+
+And after we set which program to use we can set the value for the uniform we created.
+`gl.useProgram` is like `gl.bindBuffer` above in that it sets the current program. After
+that all the `gl.uniformXXX` functions set uniforms on the current program.
+
+    gl.useProgram(program);
+
+    // Pass in the canvas resolution so we can convert from
+    // pixels to clipspace in the shader
+    gl.uniform2f(resolutionUniformLocation, gl.canvas.width, gl.canvas.height);
+
+And of course to draw 2 triangles we need to have WebGL call our vertex shader 6 times
+so we need to change the `count` to `6`.
+
+    // draw
+    var primitiveType = gl.TRIANGLES;
+    var offset = 0;
+    *var count = 6;
+    gl.drawArrays(primitiveType, offset, count);
+
+And here it is
+
+Note: This example and all following examples use [`webgl-utils.js`](/webgl/resources/webgl-utils.js)
+which contains functions to compile and link the shaders. No reason to clutter the examples
+with that [boilerplate](webgl-boilerplate.html) code.
+
+{{{example url="../webgl-2d-rectangle.html" }}}
+
+Again you might notice the rectangle is near the bottom of that area. WebGL considers the bottom left
+corner to be 0,0. To get it to be the more traditional top left corner used for 2d graphics APIs
+we can just flip the clip space y coordinate.
+
+    *   gl_Position = vec4(clipSpace * vec2(1, -1), 0, 1);
+
+And now our rectangle is where we expect it.
+
+{{{example url="../webgl-2d-rectangle-top-left.html" }}}
+
+Let's make the code that defines a rectangle into a function so
+we can call it for different sized rectangles. While we're at it
+we'll make the color settable.
+
+First we make the fragment shader take a color uniform input.
+
+    #version 300 es
+
+    precision mediump float;
+
+    +  uniform vec4 u_color;
+
+    out vec4 outColor;
+
+    void main() {
+    -  outColor = vec4(1, 0, 0.5, 1);
+    *  outColor = u_color;
+    }
+
+And here's the new code that draws 50 rectangles in random places and random colors.
+
+      var colorLocation = gl.getUniformLocation(program, "u_color");
+      ...
+
+      // draw 50 random rectangles in random colors
+      for (var ii = 0; ii < 50; ++ii) {
+        // Setup a random rectangle
+        setRectangle(
+            gl, randomInt(300), randomInt(300), randomInt(300), randomInt(300));
+
+        // Set a random color.
+        gl.uniform4f(colorLocation, Math.random(), Math.random(), Math.random(), 1);
+
+        // Draw the rectangle.
+        var primitiveType = gl.TRIANGLES;
+        var offset = 0;
+        var count = 6;
+        gl.drawArrays(primitiveType, offset, count);
+      }
+    }
+
+    // Returns a random integer from 0 to range - 1.
+    function randomInt(range) {
+      return Math.floor(Math.random() * range);
+    }
+
+    // Fills the buffer with the values that define a rectangle.
+
+    function setRectangle(gl, x, y, width, height) {
+      var x1 = x;
+      var x2 = x + width;
+      var y1 = y;
+      var y2 = y + height;
+
+      // NOTE: gl.bufferData(gl.ARRAY_BUFFER, ...) will affect
+      // whatever buffer is bound to the `ARRAY_BUFFER` bind point
+      // but so far we only have one buffer. If we had more than one
+      // buffer we'd want to bind that buffer to `ARRAY_BUFFER` first.
+
+      gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([
+         x1, y1,
+         x2, y1,
+         x1, y2,
+         x1, y2,
+         x2, y1,
+         x2, y2]), gl.STATIC_DRAW);
+    }
+
+And here's the rectangles.
+
+{{{example url="../webgl-2d-rectangles.html" }}}
+
+I hope you can see that WebGL is actually a pretty simple API.
+Okay, simple might be the wrong word. What it does is simple. It just
+executes 2 user supplied functions, a vertex shader and fragment shader and
+draws triangles, lines, or points.
+While it can get more complicated to do 3D that complication is
+added by you, the programmer, in the form of more complex shaders.
+The WebGL API itself is just a rasterizer and conceptually fairly simple.
+
+We covered a small example that showed how to supply data in an attribute and 2 uniforms.
+It's common to have multiple attributes and many uniforms. Near the top of this article
+we also mentioned *varyings* and *textures*. Those will show up in subsequent lessons.
+
+Before we move on I want to mention that for *most* applications updating
+the data in a buffer like we did in `setRectangle` is not common. I used that
+example because I thought it was easiest to explain since it shows pixel coordinates
+as input and demonstrates doing a small amount of math in GLSL. It's not wrong, there
+are plenty of cases where it's the right thing to do, but you should [keep reading to find out
+the more common way to position, orient and scale things in WebGL](webgl-2d-translation.html).
+
+If you're 100% new to WebGL and have no idea what GLSL is or shaders or what the GPU does
+then checkout [the basics of how WebGL really works](webgl-how-it-works.html).
+
+You should also, at least briefly read about [the boilerplate code used here](webgl-boilerplate.html)
+that is used in most of the examples. You should also at least skim
+[how to draw mulitple things](webgl-drawing-multiple-things.html) to give you some idea
+of how more typical WebGL apps are structured because unfortunately nearly all the examples
+only draw one thing and so do not show that structure.
+
+Otherwise from here you can go in 2 directions. If you are interested in image procesing
+I'll show you [how to do some 2D image processing](webgl-image-processing.html).
+If you are interesting in learning about translation,
+rotation and scale then [start here](webgl-2d-translation.html).

--- a/webgl/lessons/pt-br/webgl-fundamentals.md
+++ b/webgl/lessons/pt-br/webgl-fundamentals.md
@@ -348,81 +348,82 @@ Para isso, chamamos `gl.viewport` e passamos o tamanho atual da tela (canvas).
 
     gl.viewport(0, 0, gl.canvas.width, gl.canvas.height);
 
-This tells WebGL the -1 +1 clip space maps to 0 &lt;-&gt; `gl.canvas.width` for x and 0 &lt;-&gt; `gl.canvas.height`
-for y.
+Isso diz para a WebGL que o clip space -1 +1 mapeia para o 0 &lt;-&gt; `gl.canvas.width` para x e 0 &lt;-&gt; `gl.canvas.height`
+para y.
 
-We clear the canvas. `0, 0, 0, 0` are red, green, blue, alpha respectively so in this case we're making the canvas transparent.
+Agora, nós limpamos nosso canvas. `0, 0, 0, 0` são vermelho, verde, azul, alpha, respectivamente, então, nesse caso, estamos definindo o canvas como transparente.
 
-    // Clear the canvas
+    // Limpar o canvas
     gl.clearColor(0, 0, 0, 0);
     gl.clear(gl.COLOR_BUFFER_BIT);
 
-Next we need to tell WebGL which shader program to execute.
+Em seguida, precisamos dizer ao WebGL qual shader é executado.
 
-    // Tell it to use our program (pair of shaders)
+    // Fala para usar nosso program (par de shaders)
     gl.useProgram(program);
 
-Then we need to tell it which set of buffers use and how to pull data out of those buffers to
-supply to the attributes
+Então precisamos informar qual é o conjunto de buffers usar e como obter os dados desses buffers
+e então fornecer os dados aos atributos
 
-    // Bind the attribute/buffer set we want.
+    // Vincule o atributo/buffer que desejamos.
     gl.bindVertexArray(vao);
 
-After all that we can finally ask WebGL to execute our GLSL program.
+
+Depois de tudo o que fizeemos, finalmente, podemos pedir a WebGL que execute o nosso programa GLSL.
 
     var primitiveType = gl.TRIANGLES;
     var offset = 0;
     var count = 3;
     gl.drawArrays(primitiveType, offset, count);
 
-Because the count is 3 this will execute our vertex shader 3 times. The first time `a_position.x` and `a_position.y`
-in our vertex shader attribute will be set to the first 2 values from the positionBuffer.
-The 2nd time `a_position.xy` will be set to the 2nd two values. The last time it will be
-set to the last 2 values.
+Como a contagem é 3, isso executará o nosso vertex shader 3 vezes. A primeira vez `a_position.x` e `a_position.y`
+em nosso atributo vertex shader será configurado para os dois primeiros valores do positionBuffer.
+A segunda vez `a_position.xy` será configurado para os dois segundos valores. Na última vez, ele será
+configurado para os últimos 2 valores.
 
-Because we set `primitiveType` to `gl.TRIANGLES`, each time our vertex shader is run 3 times
-WebGL will draw a triangle based on the 3 values we set `gl_Position` to. No matter what size
-our canvas is those values are in clip space coordinates that go from -1 to 1 in each direction.
+Como definimos `primitiveType` para `gl.TRIANGLES`, cada vez que nosso vertex shader é executado 3 vezes,
+a WebGL desenhará um triângulo com base nos 3 valores que definimos em `gl_Position`. Não importa o tamanho da
+nossa tela, esses valores estão nas coordenadas do nosso clip space que vão de -1 a 1 em cada direção.
 
-Because our vertex shader is simply copying our positionBuffer values to `gl_Position` the
-triangle will be drawn at clip space coordinates
+Como o nosso vertex shader está simplesmente copiando os valores do nosso positionbuffer para a `gl_Position`, o
+o triângulo será desenhado nas coordenadas do clip space
 
       0, 0,
       0, 0.5,
       0.7, 0,
 
-Converting from clip space to screen space if the canvas size
-happned to be 400x300 we'd get something like this
+Convertendo do clip space para o espaço da tela se o tamanho da tela
+passasse ser 400x300, nós teríamos algo assim
 
      clip space      screen space
        0, 0       ->   200, 150
        0, 0.5     ->   200, 225
      0.7, 0       ->   340, 150
 
-WebGL will now render that triangle. For every pixel it is about to draw WebGL will call our fragment shader.
-Our fragment shader just sets `outColor` to `1, 0, 0.5, 1`. Since the Canvas is an 8bit
-per channel canvas that means WebGL is going to write the values `[255, 0, 127, 255]` into the canvas.
+A WebGL agora renderizará esse triângulo. Para cada pixel que está prestes a desenhar, a WebGL chamará o nosso fragment shader.
+Nosso fragment shader apenas define a `outColor` para `1, 0, 0.5, 1`. Como o Canvas é um canvas de 8bits
+por canal, significa que, a WebGL vai escrever os seguintes valores `[255, 0, 127, 255]` na tela.
 
-Here's a live version
+Aqui está um exemplo já pronto
 
 {{{example url="../webgl-fundamentals.html" }}}
 
-In the case above you can see our vertex shader is doing nothing
-but passing on our position data directly. Since the position data is
-already in clipspace there is no work to do. *If you want 3D it's up to you
-to supply shaders that convert from 3D to clipspace because WebGL is only
-a rasterization API*.
+No caso acima, você pode ver que o nosso vertex shader não está fazendo nada
+além de passar nossos dados de posição diretamente. Como os dados da posição já
+estão no clipspace, não há trabalho a fazer. *Se você quer objetos 3D, só depende de você
+fornecer shaders que convertam de 3D para clipspace porque a WebGL é, apenas,
+uma API de rasterização*.
 
-You might be wondering why does the triangle start in the middle and go to toward the top right.
-Clip space in `x` goes from -1 to +1. That means 0 is in the center and positive values will
-be to the right of that.
+Você pode estar se perguntando por que o triângulo começa no meio e vai para o canto superior direito.
+O clip space em `x` vai de -1 a +1. Isso significa que o 0 está no centro e os valores positivos
+irão para à direita dele.
 
-As for why it's on the top, in clip space -1 is at the bottom and +1 is at the top. That means
-0 is in the center and so positive numbers will be above the center.
+Quanto ao porquê está no topo, o clip space -1 está na parte inferior e +1 está no topo.
+Isso significa que, o 0 está no centro e os números positivos estarão acima do centro.
 
-For 2D stuff you would probably rather work in pixels than clipspace so
-let's change the shader so we can supply the position in pixels and have
-it convert to clipspace for us. Here's the new vertex shader
+Para coisas 2D, você provavelmente iria preferir trabalhar em pixels do que com o clipspace
+então vamos mudar o shader para que possamos fornecer a posição em pixels e
+convertê-lo em um clipspace para nós. Aqui está o novo vertex shader
 
     -  in vec4 a_position;
     +  in vec2 a_position;
@@ -430,31 +431,31 @@ it convert to clipspace for us. Here's the new vertex shader
     +  uniform vec2 u_resolution;
 
       void main() {
-    +    // convert the position from pixels to 0.0 to 1.0
+    +    // converte a posição dos pixels de 0.0 para 1.0
     +    vec2 zeroToOne = a_position / u_resolution;
     +
-    +    // convert from 0->1 to 0->2
+    +    // converte de 0->1 para 0->2
     +    vec2 zeroToTwo = zeroToOne * 2.0;
     +
-    +    // convert from 0->2 to -1->+1 (clipspace)
+    +    // converte de 0->2 para -1->+1 (clipspace)
     +    vec2 clipSpace = zeroToTwo - 1.0;
     +
     *    gl_Position = vec4(clipSpace, 0, 1);
       }
 
-Some things to notice about the changes. We changed `a_position` to a `vec2` since we're
-only using `x` and `y` anyway. A `vec2` is similar to a `vec4` but only has `x` and `y`.
+Algumas coisas que devemos notar sobre as mudanças. Nós mudamos a `a_position` para um `vec2` já que nós
+estamos apenas usando `x` e `y`. Um `vec2` é semelhante a um `vec4`, porém, possui apenas `x` e `y`.
 
-Next we added a `uniform` called `u_resolution`. To set that we need to look up its location.
+Em seguida, adicionamos um `uniform` chamado `u_resolution`. Para definir que precisamos procurar por sua localização.
 
     var resolutionUniformLocation = gl.getUniformLocation(program, "u_resolution");
 
-The rest should be clear from the comments. By setting `u_resolution` to the resolution
-of our canvas the shader will now take the positions we put in `positionBuffer` supplied
-in pixels coordinates and convert them to clip space.
+O reste deve estar claro a partir dos comentários. Ao configurar `u_resolution` para a resolução
+do nosso canvas, o shader vai agora tomar as posições que colocamos no `positionBuffer` fornecido
+nas coordenadas dos pixels e convertê-los em clip space.
 
-Now we can change our position values from clip space to pixels. This time we're going to draw a rectangle
-made from 2 triangles, 3 points each.
+Agora podemos alterar os valores da nossa posição do clip space para pixels. Desta vez,
+vamos desenhar um retângulo feito de 2 triângulos, 3 pontos, cada.
 
     var positions = [
     *  10, 20,
@@ -466,48 +467,48 @@ made from 2 triangles, 3 points each.
     ];
     gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(positions), gl.STATIC_DRAW);
 
-And after we set which program to use we can set the value for the uniform we created.
-`gl.useProgram` is like `gl.bindBuffer` above in that it sets the current program. After
-that all the `gl.uniformXXX` functions set uniforms on the current program.
+E depois de definirmos qual programa usar, podemos definir o valor do uniform que criamos.
+`gl.useProgram` é como `gl.bindBuffer` acima, em que ele define o programa atual.
+Depois de tudo, as funções `gl.uniformXXX` definem os uniforms no programa atual.
 
     gl.useProgram(program);
 
-    // Pass in the canvas resolution so we can convert from
-    // pixels to clipspace in the shader
+	// Passa a resolução do canvas, assim nós podemos converter
+	// de pixels para clipspace no shader
     gl.uniform2f(resolutionUniformLocation, gl.canvas.width, gl.canvas.height);
 
-And of course to draw 2 triangles we need to have WebGL call our vertex shader 6 times
-so we need to change the `count` to `6`.
+E, claro, para desenhar dois triângulos, precisamos que a WebGL chame nosso vertex shader 6 vezes,
+para isso, precisamos mudar o `count` para `6`.
 
-    // draw
+    // desenha
     var primitiveType = gl.TRIANGLES;
     var offset = 0;
     *var count = 6;
     gl.drawArrays(primitiveType, offset, count);
 
-And here it is
+E aqui está
 
-Note: This example and all following examples use [`webgl-utils.js`](/webgl/resources/webgl-utils.js)
-which contains functions to compile and link the shaders. No reason to clutter the examples
-with that [boilerplate](webgl-boilerplate.html) code.
+Nota: Este exemplo e todos os exemplos a seguir usam [`webgl-utils.js`](/webgl/resources/webgl-utils.js)
+que contém funções para compilar e vincular os shaders. Não há nenhuma razão para desordenar os
+exemplos com o [boilerplate](webgl-boilerplate.html).
 
 {{{example url="../webgl-2d-rectangle.html" }}}
 
-Again you might notice the rectangle is near the bottom of that area. WebGL considers the bottom left
-corner to be 0,0. To get it to be the more traditional top left corner used for 2d graphics APIs
-we can just flip the clip space y coordinate.
+Novamente, você pode notar que o retângulo está perto do fundo dessa área. A WebGL considera que o canto 
+inferior esquerdo é 0,0. Para que ele seja o tradicional canto superior esquerdo, usado nas APIS de gráficos
+2D, nós podemos simplesmente virar a coordenada y do clipspace.
 
     *   gl_Position = vec4(clipSpace * vec2(1, -1), 0, 1);
 
-And now our rectangle is where we expect it.
+E agora o nosso retângulo está aonde esperavamos.
 
 {{{example url="../webgl-2d-rectangle-top-left.html" }}}
 
-Let's make the code that defines a rectangle into a function so
-we can call it for different sized rectangles. While we're at it
-we'll make the color settable.
+Vamos fazer o código que define um retângulo em uma função para
+podermos chamá-lo para retângulos de diferentes tamanhos. Enquanto estamos nisso,
+nós tornaremos a cor ajustável.
 
-First we make the fragment shader take a color uniform input.
+Primeiro fazemos o fragment shader pegar uma color uniform input.
 
     #version 300 es
 
@@ -522,21 +523,21 @@ First we make the fragment shader take a color uniform input.
     *  outColor = u_color;
     }
 
-And here's the new code that draws 50 rectangles in random places and random colors.
+E aqui está o novo código que desenha 50 retângulos com cores e locais aleatórios.
 
       var colorLocation = gl.getUniformLocation(program, "u_color");
       ...
 
-      // draw 50 random rectangles in random colors
+      // desenha 50 retângulos com cores e locais aleatórios
       for (var ii = 0; ii < 50; ++ii) {
-        // Setup a random rectangle
+        // Define um retângulo aleatório
         setRectangle(
             gl, randomInt(300), randomInt(300), randomInt(300), randomInt(300));
 
-        // Set a random color.
+        // Define uma cor aleatória.
         gl.uniform4f(colorLocation, Math.random(), Math.random(), Math.random(), 1);
 
-        // Draw the rectangle.
+        // Desenha o retângulo.
         var primitiveType = gl.TRIANGLES;
         var offset = 0;
         var count = 6;
@@ -544,12 +545,12 @@ And here's the new code that draws 50 rectangles in random places and random col
       }
     }
 
-    // Returns a random integer from 0 to range - 1.
+    // Retorna um inteiro aleatório entre o intervalo de 0 e - 1.
     function randomInt(range) {
       return Math.floor(Math.random() * range);
     }
 
-    // Fills the buffer with the values that define a rectangle.
+    // Preenche o buffer com os valores que definem um retângulo.
 
     function setRectangle(gl, x, y, width, height) {
       var x1 = x;
@@ -557,10 +558,10 @@ And here's the new code that draws 50 rectangles in random places and random col
       var y1 = y;
       var y2 = y + height;
 
-      // NOTE: gl.bufferData(gl.ARRAY_BUFFER, ...) will affect
-      // whatever buffer is bound to the `ARRAY_BUFFER` bind point
-      // but so far we only have one buffer. If we had more than one
-      // buffer we'd want to bind that buffer to `ARRAY_BUFFER` first.
+      // NOTA: gl.bufferData(gl.ARRAY_BUFFER, ...) afetará
+      // qualquer buffer que esteja vinculado ao `ARRAY_BUFFER`,
+      // mas até agora temos apenas um buffer. Se tivessémos mais de um
+      // buffer, gostaríamos de vincular este buffer a `ARRAY_BUFFER` primeiro.
 
       gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([
          x1, y1,
@@ -571,39 +572,38 @@ And here's the new code that draws 50 rectangles in random places and random col
          x2, y2]), gl.STATIC_DRAW);
     }
 
-And here's the rectangles.
+E aqui está os retângulos.
 
 {{{example url="../webgl-2d-rectangles.html" }}}
 
-I hope you can see that WebGL is actually a pretty simple API.
-Okay, simple might be the wrong word. What it does is simple. It just
-executes 2 user supplied functions, a vertex shader and fragment shader and
-draws triangles, lines, or points.
-While it can get more complicated to do 3D that complication is
-added by you, the programmer, in the form of more complex shaders.
-The WebGL API itself is just a rasterizer and conceptually fairly simple.
+Espero que você veja que a WebGL é realmente uma API bastante simples.
+Tudo bem, simples pode ser a palavra errada. Mas o que ela faz é simples. Ela apenas
+executa 2 funções fornecidas pelo usuário, um vertex shader e um fragment shader e
+desenha triângulos, linhas ou pontos.
+Embora possa ser mais complicado fazer uma abordagem 3D, essa complicação é
+definida por você, o programador, sob a forma de shaders mais complexos.
+A própria API da WebGL é apenas um rasterizador e, conceitualmente, bastante simples.
 
-We covered a small example that showed how to supply data in an attribute and 2 uniforms.
-It's common to have multiple attributes and many uniforms. Near the top of this article
-we also mentioned *varyings* and *textures*. Those will show up in subsequent lessons.
+Cobrimos um pequeno exemplo que mostrou como fornecer dados em um atributo e 2 uniforms.
+É comum ter múltiplos atributos e muitos uniforms. Perto do topo deste artigo
+também mencionamos *variáveis* e *texturas*. Isso aparecerá em lições subsequentes.
 
-Before we move on I want to mention that for *most* applications updating
-the data in a buffer like we did in `setRectangle` is not common. I used that
-example because I thought it was easiest to explain since it shows pixel coordinates
-as input and demonstrates doing a small amount of math in GLSL. It's not wrong, there
-are plenty of cases where it's the right thing to do, but you should [keep reading to find out
-the more common way to position, orient and scale things in WebGL](webgl-2d-translation.html).
+Antes de avançarmos, quero mencionar que para *a maioria das* aplicações em atualização
+os dados em um buffer, como fizemos em `setRectangle`, não são comuns. Usei esso
+exemplo porque pensei que era mais fácil de explicar porque mostra coordenadas de pixels
+como entrada e demonstra como fazer uma pequena quantidade de matemática na GLSL. Não é errado, há
+muitos os casos em que isso é o certo a se fazer, mas você deve [continuar lendo para descobrir
+a maneira mais comum de posicionar, orientar e dimensionar coisas na WebGL](webgl-2d-translation.html).
 
-If you're 100% new to WebGL and have no idea what GLSL is or shaders or what the GPU does
-then checkout [the basics of how WebGL really works](webgl-how-it-works.html).
+Se você é 100% leigo na WebGL e não tem ideia do que é GLSL ou shaders ou o que a GPU faz, então,
+em seguida, verifique [os conceitos básicos de como a WebGL realmente funciona] (webgl-how-it-works.html).(webgl-how-it-works.html).
 
-You should also, at least briefly read about [the boilerplate code used here](webgl-boilerplate.html)
-that is used in most of the examples. You should also at least skim
-[how to draw mulitple things](webgl-drawing-multiple-things.html) to give you some idea
-of how more typical WebGL apps are structured because unfortunately nearly all the examples
-only draw one thing and so do not show that structure.
+Você também deve, pelo menos, ler brevemente sobre [o código boilerplate usado aqui](webgl-boilerplate.html)
+que é usado na maioria dos exemplos. Você também deve, pelo menos ver
+[como desenhar múltiplas coisas](webgl-drawing-multiple-things.html) para ter uma ideia de como
+as aplicações em WebGL são estruturadas porque, infelizmente, apenas desenha algo e, portanto, não mostra essa estrutura.
 
-Otherwise from here you can go in 2 directions. If you are interested in image procesing
-I'll show you [how to do some 2D image processing](webgl-image-processing.html).
-If you are interesting in learning about translation,
-rotation and scale then [start here](webgl-2d-translation.html).
+Caso contrário, a partir daqui você pode ir em duas direções. Se você está interessado em processar imagens
+Vou lhes mostrar [como fazer algum processamento de imagem 2D](webgl-image-processing.html).
+Se você está interessado em aprender sobre translação, rotação e escala, então,
+[comece aqui](webgl-2d-translation.html).

--- a/webgl/lessons/pt-br/webgl-fundamentals.md
+++ b/webgl/lessons/pt-br/webgl-fundamentals.md
@@ -193,17 +193,18 @@ em literais de templates multilinha.
     }
     `;
 
-In fact, most 3D engines generate GLSL shaders on the fly using various types of templates, concatenation, etc.
-For the samples on this site though none of them are complex enough to need to generate GLSL at runtime.
+Na verdade, a maioria dos motores 3D geram shaders GLSL com case em vários tipos de templates, concatenação, etc.
+Para as amostras neste site, nenhuma delas é suficientemente complexa para precisar
+gerar GLSL em tempo de execução.
 
-> NOTE: `#version 300 es` **MUST BE THE VERY FIRST LINE OF YOUR SHADER**. No comments or
-> blank lines are allowed before it! `#version 300 es` tells WebGL2 you want to use WebGL2's
-> shader language called GLSL ES 3.00. If you don't put that as the first line the shader
-> language defaults to WebGL 1.0's GLSL ES 1.00 which has many differences and far less features.
+> NOTE: `#version 300 es` **DEVE SER A PRIMEIRA LINHA DO SEUS SHADER**. Nenhum comentário ou
+> linhas em branco são permitidas antes dele! `#version 300 es` diz para a WebGL2 que você deseja
+> usar a linguagem de shader da WebGL2, chamada GLSL ES 3.00. Se você não colocar isso como a primeira linha, a linguagem padrão
+> do shader será definida para a da WebGL 1.0, a GLSL ES 1.00 que possui muitas diferenças e bem menos recursos.
 
-Next we need a function that will create a shader, upload the GLSL source, and compile the shader.
-Note I haven't written any comments because it should be clear from the names of the functions
-what is happening.
+Em seguida, precisamos de uma função que irá criar uma shader, faça o upload da fonte GLSL e compile o shader.
+Note que eu não escrevi nenhum comentários visto que através do nome das funções é fácil
+compreender o que está acontecendo.
 
     function createShader(gl, type, source) {
       var shader = gl.createShader(type);
@@ -218,12 +219,12 @@ what is happening.
       gl.deleteShader(shader);
     }
 
-We can now call that function to create the 2 shaders
+Agora podemos chamar essa função para criar os 2 shaders
 
     var vertexShader = createShader(gl, gl.VERTEX_SHADER, vertexShaderSource);
     var fragmentShader = createShader(gl, gl.FRAGMENT_SHADER, fragmentShaderSource);
 
-We then need to *link* those 2 shaders into a *program*
+Nós, então, precisamos *linkar* aqueles 2 shaders em um *program*
 
     function createProgram(gl, vertexShader, fragmentShader) {
       var program = gl.createProgram();
@@ -239,35 +240,35 @@ We then need to *link* those 2 shaders into a *program*
       gl.deleteProgram(program);
     }
 
-And call it
+E chame isso
 
     var program = createProgram(gl, vertexShader, fragmentShader);
 
-Now that we've created a GLSL program on the GPU we need to supply data to it.
-The majority of the WebGL API is about setting up state to supply data to our GLSL programs.
-In this case our only input to our GLSL program is `a_position` which is an attribute.
-The first thing we should do is look up the location of the attribute for the program
-we just created
+Agora que criamos um programa GLSL na GPU, precisamos fornecer dados para ele.
+A maioria da API da WebGL se trata de configurar o estado para fornecer dados aos nossos programas GLSL.
+Nesse caso, nossa única entrada para o nosso programa GLSL é `a_position`, que por sua vez, é um atributo.
+A primeira coisa que devemos fazer é procurar a localização do atributo para o programa
+que nós acabamos de criar
 
     var positionAttributeLocation = gl.getAttribLocation(program, "a_position");
 
-Looking up attribute locations (and uniform locations) is something you should
-do during initialization, not in your render loop.
+Procurar posições de atributos (e locais uniformes) é algo que você deve
+fazer durante a inicialização, e não no seu loop de renderização.
 
-Attributes get their data from buffers so we need to create a buffer
+Atributos obtêm seus dados através de buffers, então, nós precisamos criar um buffer
 
     var positionBuffer = gl.createBuffer();
 
-WebGL lets us manipulate many WebGL resources on global bind points.
-You can think of bind points as internal global variables inside WebGL.
-First you bind a resource to a bind point. Then, all other functions
-refer to the resource through the bind point. So, let's bind the position buffer.
+A WebGL nos permite manipular muitos recursos da WebGL em pontos de consolidação global.
+Você pode pensar em pontos de ligação como variáveis internas globais dentro da WebGL.
+Primeiro, você vincula um recurso a um ponto de ligação. E então, todas as outras funções
+ao recurso através do ponto de ligação. Então, vamos vincular o buffer de posição.
 
     gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
 
-Now we can put data in that buffer by referencing it through the bind point
+Agora podemos colocar dados nesse buffer, referenciando-o através do ponto de ligação
 
-    // three 2d points
+    // três pontos 2d
     var positions = [
       0, 0,
       0, 0.5,
@@ -275,74 +276,75 @@ Now we can put data in that buffer by referencing it through the bind point
     ];
     gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(positions), gl.STATIC_DRAW);
 
-There's a lot going on here. The first thing is we have `positions` which is a
-JavaScript array. WebGL on other hand needs strongly typed data so the part
-`new Float32Array(positions)` creates a new array of 32bit floating point numbers
-and copies the values from `positions`. `gl.bufferData` then copies that data to
-the `positionBuffer` on the GPU. It's using the position buffer because we bound
-it to the `ARRAY_BUFFER` bind point above.
+Há muita coisa acontecendo aqui. A primeira coisa que temos é `positions`, que é um
+array em JavaScript. A WebGL, por outro lado, precisa de dados fortemente tipados, e então
+a parte `new Float32Array(position)` cria uma nova matriz de números de pontos flutuantes de 32 bits
+e copia os valores de `positions`. Então, `gl.bufferData` copia esses dados para o `positionBuffer` na GPU. O
+buffer de posição está sendo usado porque nós o vinculamos ao ponto de ligação `ARRAY_BUFFER` acima.
 
-The last argument, `gl.STATIC_DRAW` is a hint to WebGL about how we'll use the data.
-WebGL can try to use that hint to optimize certain things. `gl.STATIC_DRAW` tells WebGL
-we are not likely to change this data much.
+O último argumento, `gl.STATIC_DRAW` é uma dica para a WebGL sobre como usaremos os dados.
+A WebGL pode tentar usar essa sugestão para otimizar certas coisas. `gl.STATIC_DRAW` diz para a WebGL
+que não é provável que mudemos muito esses dados.
 
-Now that we've put data in a buffer we need to tell the attribute how to get data
-out of it. First we need to create a collection of attribute state called a Vertex Array Object.
+Agora que colocamos dados em um buffer, precisamos mostrar ao atributo como obter os dados dele.
+Primeiro, precisamos criar uma coleção do estado do atributo denominada Vertex Array Object.
 
     var vao = gl.createVertexArray();
 
-And we need to make that the current vertex array so that all of our attribute settings
-will apply to that set of attribute state
+E precisamos fazer com que ele seja o vertex array atual para que todas as nossas
+configurações de atributos se apliquem a esse conjunto de estado de atributos
 
     gl.bindVertexArray(vao);
 
-Now we finally setup the attributes in the vertex array. First off we need to turn the attribute on.
-This tells WebGL we want to get data out of a buffer. If we don't turn on the attribute
-then the attribute will have a constant value.
+Finalmente, nós configuramos os atributos no vertex array. Em primeiro lugar, precisamos ativar o atributo.
+Isso fala para a WebGL que queremos tirar dados de um buffer. Se não ativarmos o atributo, então, o atributo
+terá um valor constante.
 
     gl.enableVertexAttribArray(positionAttributeLocation);
 
-Then we need to specify how to pull the data out
+Então, nós precisamos especificar como obter os dados
 
-    var size = 2;          // 2 components per iteration
-    var type = gl.FLOAT;   // the data is 32bit floats
-    var normalize = false; // don't normalize the data
-    var stride = 0;        // 0 = move forward size * sizeof(type) each iteration to get the next position
-    var offset = 0;        // start at the beginning of the buffer
+    var size = 2;          // 2 componentes por iteração
+    var type = gl.FLOAT;   // os dados são floats de 32bits
+    var normalize = false; // não normalize os dados
+    var stride = 0;        // 0 = mover para frente size * sizeof(type) cada iteração para obter a próxima posição
+    var offset = 0;        // comece no início do buffer
     gl.vertexAttribPointer(
         positionAttributeLocation, size, type, normalize, stride, offset)
 
-A hidden part of `gl.vertexAttribPointer` is that it binds the current `ARRAY_BUFFER`
-to the attribute. In other words now this attribute is bound to
-`positionBuffer`. That means we're free to bind something else to the `ARRAY_BUFFER` bind point.
-The attribute will continue to use `positionBuffer`.
+Uma parte oculta da `gl.vertexAttribPointer` é que ela vincula o atual `ARRAY_BUFFER`
+ao atributo. Em outras palavras, agora esse atributo é obrigado a vincular o `positionBuffer`.
+Isso significa que estamos livres para ligar outra coisa ao ponto de ligação `ARRAY_BUFFER`;
+O atributo continuará usando o `positionBuffer`.
 
-Note that from the point of view of our GLSL vertex shader the `a_position` attribute is a `vec4`
+Observe que, do ponto de vista do nosso GLSL vertex shader, o atributo `a_position` é um `vec4`
 
     in vec4 a_position;
 
-`vec4` is a 4 float value. In JavaScript you could think of it something like
-`a_position = {x: 0, y: 0, z: 0, w: 0}`. Above we set `size = 2`. Attributes
-default to `0, 0, 0, 1` so this attribute will get its first 2 values (x and y)
-from our buffer. The z, and w will be the default 0 and 1 respectively.
+`vec4` é um 4 float value. Em JavaScript, você poderia pensar em algo como
+`a_position = {x: 0, y: 0, z: 0, w: 0}`. Acima, nós definimos `size = 2`. Atributos
+padrão para `0, 0, 0, 1` então esse atributo receberá seus primeiros 2 valores (x e y)
+do nosso buffer. O z e o w, será o padrão 0 e 1, respectivamente.
 
-Before we draw we should resize the canvas to match its display size. Canvases just like Images have 2 sizes.
-The number of pixels actually in them and separately the size they are displayed. CSS determines the size
-the canvas is displayed. **You should always set the size you want a canvas with CSS** since it is far far
-more flexible than any other method.
+Antes de desenharmos, devemos redimensionar nosso canvas (ou nossa tela) para corresponder com o nosso tamanho de exibição. As telas, como as imagens, possuem 2 tamanhos.
+O número real de pixels em si e separadamente o tamanho que eles são exibidos.
+O CSS determina o tamanho que o canvas é exibido. **Você sempre deve definir o tamanho que deseja
+uma tela com o CSS**, pois é muito mais flexível do que qualquer outro método.
 
-To make the number of pixels in the canvas match the size it's displayed
-[I'm using a helper function you can read about here](webgl-resizing-the-canvas.html).
+Para fazer com que o número de pixels na tela coincida com o tamanho exibido
+[eu faço o uso de um helper, mais detalhes aqui](webgl-resizing-the-canvas.html).
 
-In nearly all of these samples the canvas size is 400x300 pixels if the sample is run in its own window
-but stretches to fill the available space if it's inside an iframe like it is on this page.
-By letting CSS determine the size and then adjusting to match we easily handle both of these cases.
+Em quase todas essas amostras, o tamanho da tela é de 400x300 pixels se a anistra for executada 
+em sua própria janela, mas ela se estende para preencher o espaço disponível se estiver dentro de um iframe
+como ele está nesta página.
+Ao permitir que o CSS determine o tamanho e, em seguida, ajuste seus tamanho para  corresponder ao da tela,
+nós facilmente manipulamos ambos os casos.
 
     webglUtils.resizeCanvasToDisplaySize(gl.canvas);
 
-We need to tell WebGL how to convert from the clip space
-values we'll be setting `gl_Position` to back into pixels, often called screen space.
-To do this we call `gl.viewport` and pass it the current size of the canvas.
+Precisamos dizer ao WebGL como converter valores do clip space,
+nós vamos configurar o `gl_Position` de volta para pixels, muitas vezes chamado de screen space.
+Para isso, chamamos `gl.viewport` e passamos o tamanho atual da tela (canvas).
 
     gl.viewport(0, 0, gl.canvas.width, gl.canvas.height);
 

--- a/webgl/lessons/pt-br/webgl-fundamentals.md
+++ b/webgl/lessons/pt-br/webgl-fundamentals.md
@@ -69,34 +69,34 @@ Há quatro maneiras de como um shader é capaz de obter dados.
 
 ## WebGL Hello World
 
-WebGL only cares about 2 things. Clipspace coordinates and colors.
-Your job as a programmer using WebGL is to provide WebGL with those 2 things.
-You provide your 2 "shaders" to do this. A Vertex shader which provides the
-clipspace coordinates and a fragment shader that provides the color.
+A WebGL se preocupa apenas com 2 coisas. Coordenadas do Clispace e cores.
+Seu trabalho como programador usando a WebGL é fornecer WebGL com essas 2 coisas.
+Você fornece seus 2 "shaders" para fazer isso. Um vexter shader que fornece fornece as
+coordenadas do Clispace e um fragment shader que fornece a cor.
 
-Clipspace coordinates always go from -1 to +1 no matter what size your
-canvas is. Here is a simple WebGL example that shows WebGL in its simplest form.
+As coordenadas do Clispace sempre vão de -1 a +1, independentemente do tamanho do seu canvas.
+Aqui está um simples exemplo da WebGL que a mostra em sua forma mais simples.
 
-Let's start with a vertex shader
+Vamos começar com um vertex shader
 
     #version 300 es
 
-    // an attribute is an input (in) to a vertex shader.
-    // It will receive data from a buffer
+    // um atributo é um input (in) para um vertex shader.
+    // ele receberá dados de um buffer
     in vec4 a_position;
 
-    // all shaders have a main function
+    // todos os shaders possuem uma função main
     void main() {
 
-      // gl_Position is a special variable a vertex shader
-      // is responsible for setting
+      // gl_Position é uma variável especial de um vertex shader
+      // é responsável pela configuração
       gl_Position = a_position;
     }
 
-When executed, if the entire thing was written in JavaScript instead of GLSL
-you could imagine it would be used like this
+Quando executada, se toda a coisa fosse escrita em JavaScript em vez de GLSL
+você poderia imaginar que isso seria utilizado como o exemplo abaixo
 
-    // *** PSUEDO CODE!! ***
+    // *** PSUEDO CÓDIGO!! ***
 
     var positionBuffer = [
       0, 0, 0, 0,
@@ -110,85 +110,85 @@ you could imagine it would be used like this
       var stride = 4;
       var size = 4;
       for (var i = 0; i < count; ++i) {
-         // copy the next 4 values from positionBuffer to the a_position attribute
+         // copia os 4 próximos valores do positionBuffer para o atributo a_position
          attributes.a_position = positionBuffer.slice((offset + i) * stide, size);
          runVertexShader();
          ...
          doSomethingWith_gl_Position();
     }
 
-In reality it's not quite that simple because `positionBuffer` would need to be converted to binary
-data (see below) and so the actual computation for getting data out of the buffer
-would be a little different but hopefully this gives you an idea of how a vertex
-shader will be executed.
+Na realidade, não é tão simples porque o `positionBuffer` precisa ser convertido em dados
+binários (veja abaixo) e, portanto, o cálculo real para obter os dados do buffer
+seria um pouco diferente, mas espero que isso lhe dê uma ideia de como um vertex shader
+será executado.
 
-Next we need a fragment shader
+Em seguida, nós precisamos de um fragment shader
 
     #version 300 es
 
-    // fragment shaders don't have a default precision so we need
-    // to pick one. mediump is a good default. It means "medium precision"
+    // fragment shaders não tem uma precisão padrão, então nós precisamos
+    // escolher uma. mediump é um bom valor padrão. Do Inglês "medium precision", significa "precisão média"
     precision mediump float;
 
-    // we need to declare an output for the fragment shader
+    // precisamos declarar um output para o fragment shader
     out vec4 outColor;
 
     void main() {
-      // Just set the output to a constant redish-purple
+      // Simplesmente defina o output para um constante com uma cor avermelhada-roxa
       outColor = vec4(1, 0, 0.5, 1);
     }
 
-Above we declared `outColor` as our fragment shader's output. We're setting `outColor` to `1, 0, 0.5, 1`
-which is 1 for red, 0 for green, 0.5 for blue, 1 for alpha. Colors in WebGL go from 0 to 1.
+Acima, nós declaramos `outColor` como um output do nosso fragment shader. Estamos definindo `outColor` com os valores `1, 0, 0.5, 1`
+sendo 1 para vermelho, 0 para verde, 0.5 para azul, 1 para alpha. As cores na WebGL vão de 0 a 1.
 
-Now that we have written the 2 shader functions lets get started with WebGL
+Agora que nós escrevemos as duas funções shaders, vamos iniciar com a WebGL
 
-First we need an HTML canvas element
+Primeiro precisaremos de um elemento canvas do HTML
 
      <canvas id="c"></canvas>
 
-Then in JavaScript we can look that up
+Então, em JavaScript, podemos obtê-lo da seguinte forma
 
      var canvas = document.getElementById("c");
 
-Now we can create a WebGL2RenderingContext
+Agora podemos criar um WebGL2RenderingContext
 
      var gl = canvas.getContext("webgl2");
      if (!gl) {
-        // no webgl2 for you!
+        // sem webgl2 pra você!
         ...
 
-Now we need to compile those shaders to put them on the GPU so first we need to get them into strings.
-You can create your GLSL strings any way you normally create strings in JavaScript. For example by concatenating,
-by using AJAX to download them, by putting them in non-javascript script tags, or in this case in
-multiline template strings.
+Agora precisamos compilar esses shaders para colocá-los na GPU, então primeiro precisaremos inseri-los em strings.
+Você criar suas strings GLSL da maneira que você normalmente cria strings em JavaScript. Por exemplo, concatenando,
+usando AJAX para obtê-las, colocando-as em tags de script non-javascript, ou neste caso,
+em literais de templates multilinha.
 
     var vertexShaderSource = `#version 300 es
 
-    // an attribute is an input (in) to a vertex shader.
-    // It will receive data from a buffer
+    // um atributo é um input (in) para um vertex shader.
+    // ele receberá dados de um buffer
     in vec4 a_position;
-
-    // all shaders have a main function
+	
+	// todos os shaders possuem uma função main
     void main() {
 
-      // gl_Position is a special variable a vertex shader
-      // is responsible for setting
-      gl_Position = a_position;
+    // gl_Position é uma variável especial de um vertex shader
+    // é responsável pela configuração
+    gl_Position = a_position;
     }
     `;
 
     var fragmentShaderSource = `#version 300 es
 
-    // fragment shaders don't have a default precision so we need
-    // to pick one. mediump is a good default. It means "medium precision"
+    // fragment shaders não tem uma precisão padrão, então nós precisamos
+    // escolher uma. mediump é um bom valor padrão. Do Inglês "medium precision", significa "precisão média"
     precision mediump float;
 
-    // we need to declare an output for the fragment shader
+    // precisamos declarar um output para o fragment shader
     out vec4 outColor;
 
     void main() {
-      // Just set the output to a constant redish-purple
+      // Simplesmente defina o output para um constante com uma cor avermelhada-roxa
       outColor = vec4(1, 0, 0.5, 1);
     }
     `;


### PR DESCRIPTION
## Translated articles

This one still needs to be improved. There's some japonese text that couldn't get it. So things like this I will be leaving for the future.

- WebGL Fundamentals

## Fixes

Improved the translation of "missing" attribute.

- langinfo.hanson

Links now redirect to the translated articles. I do not know if it used to be redirected to the original articles intentionally, but I changed all href values to redirect to those pt-br articles. Tell me if there's any problem.

- toc.html